### PR TITLE
Upload functionality working with Potree and Entwine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,6 @@ jib {
     }
     to {
         image = 'nexus-docker-public-hosted.ossim.io/lidar-converter-server'
-//        image = 'hercules/lidar-converter-server'
         tags = ['latest']
     }
     extraDirectories {

--- a/src/main/groovy/lidar/converter/UploadController.groovy
+++ b/src/main/groovy/lidar/converter/UploadController.groovy
@@ -1,5 +1,6 @@
 package lidar.converter
 
+import io.micronaut.context.annotation.Value
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Post
@@ -14,6 +15,9 @@ import java.nio.file.Paths
 @Controller
 class UploadController {
 
+    @Value('${lidar.converter.inputDirectory}')
+    String inputDirectory
+
     PotreeConverterService potreeConverterService
     EntwineConverterService entwineConverterService
 
@@ -23,10 +27,10 @@ class UploadController {
     }
 
     @Post(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
-    HttpResponse<String> uploadBytes(byte[] file, String fileType) {
+    HttpResponse<String> uploadBytes(byte[] file, String fileName, String fileType) {
         try {
 
-            File tmpFile = new File("_lidar_to_upload.las") // Do we want this to be random...createTempFile?
+            File tmpFile = new File("${inputDirectory}/${fileName}")
             Path path = Paths.get(tmpFile.absolutePath)
             Files.write(path, file)
 
@@ -35,7 +39,7 @@ class UploadController {
                 potreeConverterService.run(tmpFile)
 
             } else {
-               println "Entwine uploaded" // TODO: logger
+                println "Entwine uploaded" // TODO: logger
                 entwineConverterService.run(tmpFile)
             }
 

--- a/src/main/groovy/lidar/converter/UploadController.groovy
+++ b/src/main/groovy/lidar/converter/UploadController.groovy
@@ -1,0 +1,52 @@
+package lidar.converter
+
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.MediaType
+import lidar.converter.entwine.EntwineConverterService
+import lidar.converter.potree.PotreeConverterService
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+@Controller
+class UploadController {
+
+    PotreeConverterService potreeConverterService
+    EntwineConverterService entwineConverterService
+
+    UploadController(PotreeConverterService potreeConverterService, EntwineConverterService entwineConverterService) {
+        this.potreeConverterService = potreeConverterService
+        this.entwineConverterService = entwineConverterService
+    }
+
+    @Post(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA, produces = MediaType.TEXT_PLAIN)
+    HttpResponse<String> uploadBytes(byte[] file, String fileType) {
+        try {
+
+            File tmpFile = new File("_lidar_to_upload.las") // Do we want this to be random...createTempFile?
+            Path path = Paths.get(tmpFile.absolutePath)
+            Files.write(path, file)
+
+            if (fileType == "potree") {
+                println "Potree uploaded." // TODO: logger
+                potreeConverterService.run(tmpFile)
+
+            } else {
+               println "Entwine uploaded" // TODO: logger
+                entwineConverterService.run(tmpFile)
+            }
+
+            HttpResponse.ok("File uploaded successfully.")
+
+        } catch (IOException exception) {
+            println exception // TODO: logger
+            HttpResponse.badRequest("Upload Failed")
+
+        }
+    }
+
+
+}

--- a/src/main/groovy/lidar/converter/potree/PotreeConverterService.groovy
+++ b/src/main/groovy/lidar/converter/potree/PotreeConverterService.groovy
@@ -18,6 +18,8 @@ class PotreeConverterService {
     @Value('${lidar.converter.potree.outputDirectory}')
     String outputDirectory
 
+
+
     PotreeConverterService(LidarIndexerClient lidarIndexerClient, PdalService pdalService, ZipService zipService) {
         this.lidarIndexerClient = lidarIndexerClient
         this.pdalService = pdalService
@@ -25,12 +27,14 @@ class PotreeConverterService {
     }
 
     String run(File inputFile) {
+        String inputFileFullPath = inputFile.getAbsolutePath()
+
         def outputFile = "/potree/${FilenameUtils.getBaseName(inputFile.name)}"
         String outputLocation = new File(outputDirectory, outputFile)
 
         def cmd = [
                 '/usr/local/bin/PotreeConverter',
-                '--source', "${inputFile}",
+                '--source', "${inputFileFullPath}",
                 '--outdir', "${outputLocation}",
                 '--generate-page', 'index',
                 '--material', 'RGB',
@@ -64,9 +68,14 @@ class PotreeConverterService {
             lidarIndexerClient.postLidarProduct(lidarProduct)
             println stdout.toString()
 
+            // Clean up after the file has been successfully converted
+            inputFile.delete()
+
             return stdout.toString()
         } else {
+            inputFile.delete()
             return stderr.toString()
+
         }
     }
 }

--- a/src/main/groovy/lidar/converter/potree/PotreeConverterService.groovy
+++ b/src/main/groovy/lidar/converter/potree/PotreeConverterService.groovy
@@ -18,8 +18,6 @@ class PotreeConverterService {
     @Value('${lidar.converter.potree.outputDirectory}')
     String outputDirectory
 
-
-
     PotreeConverterService(LidarIndexerClient lidarIndexerClient, PdalService pdalService, ZipService zipService) {
         this.lidarIndexerClient = lidarIndexerClient
         this.pdalService = pdalService

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,10 @@
 micronaut:
   application:
     name: lidar-converter-server
-#  server:
+  server:
+    max-request-size: '1000MB'
+    multipart:
+      max-file-size: '1000MB'
 #    context-path: /lidar-converter-server
   router:
     static-resources:
@@ -19,6 +22,7 @@ micronaut:
         mapping: /swagger-ui/**
 lidar:
   converter:
+    inputDirectory: ${LIDAR_CONVERTER_INPUT_DIRECTORY:/input}
     potree:
 #      outputDirectory: /data/lidar
       outputDirectory: ${LIDAR_CONVERTER_OUTPUT_DIRECTORY:/output}


### PR DESCRIPTION
This PR allows the ability to upload files (less than 1GB) to the lidar-converter-server.  Once the files are uploaded they can be processed by either Potree or Entwine services.  

The following is an example of how to do so via curl:
curl -F "file=@input/FTSTORY_Potree_Viewshed_Imagery_sampled.las" http://localhost:8888/upload -F "fileName=FTSTORY_Potree_Viewshed_Imagery_sampled.las" -F "fileType=entwine"